### PR TITLE
Fix bug in multidna2genind and add test architecture

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,3 +12,4 @@ License: GPL (>=2)
 LazyData: true
 Collate: doc.R multidna.class.R multiphyDat.class.R show.R multidna.constructor.R multiphyDat.constructor.R accessors.R handling.R plot.R readfiles.R datasets.R dist.R exports.R
 VignetteBuilder: knitr
+Suggests: testthat

--- a/R/exports.R
+++ b/R/exports.R
@@ -52,7 +52,11 @@ multidna2genind <- function(x, genes=TRUE, mlst=FALSE, gapIsNA=FALSE){
   if (gapIsNA){
     xgap <- find_gap_sequence(xlevs)
     for (i in names(xgap)){
-      levels(xdf[[i]])[xgap[[i]]] <- NA
+      the_gap <- xgap[[i]]
+      levels(xdf[[i]])[the_gap] <- NA
+      if (length(the_gap) > 0){
+        xlevs[[i]] <- xlevs[[i]][-the_gap]        
+      }
     }    
   }
   xdfnum <- data.frame(lapply(xdf, as.numeric))

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(apex)
+
+test_check("apex")

--- a/tests/testthat/test_export.R
+++ b/tests/testthat/test_export.R
@@ -1,0 +1,30 @@
+context("Export tests")
+
+files  <- dir(system.file(package="apex"), patter="patr", full=TRUE)
+x      <- read.multiFASTA(files)
+mulphy <- multidna2multiphyDat(x)
+gensnp <- multidna2genind(x)
+genphy <- multiphyDat2genind(x)
+gengen <- multidna2genind(x, mlst = TRUE, gapIsNA = TRUE)
+muldna <- multiphyDat2multidna(mulphy)
+
+test_that("genind conversion works as expected", {
+  expect_that(gensnp, is_a("genind"))
+  expect_that(gengen, is_a("genind"))
+  expect_that(gensnp, is_equivalent_to(genphy))
+
+  expect_true(adegenet::is.genind(gensnp))
+  expect_that(adegenet::nLoc(gensnp), equals(11))
+  expect_that(adegenet::nInd(gensnp), equals(8))
+
+  expect_true(adegenet::is.genind(gengen))
+  expect_that(adegenet::nLoc(gengen), equals(length(x@dna)))
+  expect_that(adegenet::nInd(gengen), equals(8))
+})
+
+test_that("multiphyDat conversion works as expected", {
+	expect_that(mulphy, is_a("multidna"))
+	expect_that(sample(mulphy@dna, 1)[[1]], is_a("phyDat"))
+	expect_that(muldna, is_a("multidna"))
+	expect_that(sample(muldna@dna, 1)[[1]], is_a("DNAbin"))
+})


### PR DESCRIPTION
The bug was causing malformed genind object to be created when `mlst = TRUE` and `gapIsNA = TRUE`. Tests confirm that this is fixed.
