### PR TITLE
fix error in add.gaps if phyDat contains not nucleotides sequences

### DIFF
--- a/R/add.gaps.R
+++ b/R/add.gaps.R
@@ -70,21 +70,21 @@ setMethod("add.gaps", "multiphyDat", function(x, ...){
     if(is.null(x@seq)) return(x)
 
     ## FUNCTION TO REORDER MATRIX AND ADD MISSING SEQUENCES ##
-    form.dna.phyDat <- function(dna, labels){
-        ## convert dna to matrix of characters
-        dna <- as.character(dna)
-
-        ## make matrix of missing sequences if needed
+    form.dna.phyDat <- function(dna, labels, gap="-"){
+        ## add missing sequences if needed
         lab.missing <- labels[!(labels %in% labels(dna))]
         n.missing <- length(lab.missing)
         if(n.missing>0){
-            mat.NA <- matrix("-", ncol=ncol(dna), nrow=n.missing)
-            rownames(mat.NA) <- lab.missing
-            dna <- rbind(dna, mat.NA)
+            gap_code <- match(gap, attr(dna, "allLevels"))
+            nr <- attr(dna,"nr")
+            l <- length(dna)
+            tmp <- vector("list", n.missing)
+            for(i in seq_len(n.missing)) tmp[[i]] <- rep(gap_code, nr)
+            dna[(l+1L):(l+n.missing)] <- tmp
+            attr(dna, "names")[(l+1L):(l+n.missing)] <- lab.missing
         }
-
         ## return ordered sequences
-        return(as.phyDat(dna[labels,]))
+        return(subset(dna,labels))
     }
 
     ## APPLY THIS FUNCTION TO ALL MATRICES ##

--- a/R/multiphyDat.constructor.R
+++ b/R/multiphyDat.constructor.R
@@ -84,7 +84,7 @@ setMethod("initialize", "multiphyDat", function(.Object, seq=NULL, type=characte
     ## convert matrices of characters into phyDat ##
     N.GENES <- length(seq)
     for(i in 1:N.GENES){
-        if(is.character(seq[[i]])) seq[[i]] <- phyDat(seq[[i]])
+        if(is.character(seq[[i]])) seq[[i]] <- as.phyDat(seq[[i]])
     }
 
     ## replace with generic names if needed ##


### PR DESCRIPTION
Hi @thibautjombart, 
this should fix issue #49 and make `add.gaps()` independent of the data type it contains. It is very likely also faster as it does not convert the data. 